### PR TITLE
Helm: Change default docker tag

### DIFF
--- a/devops/helm/rtstreamer/values.yaml
+++ b/devops/helm/rtstreamer/values.yaml
@@ -3,5 +3,5 @@ global:
   
 rtstreamer:
   imageName: node-rtsp-rtmp-server
-  imageTag: development
+  imageTag: 19.05
 


### PR DESCRIPTION
Change to stable docker tag, currently development
isn't working